### PR TITLE
Add a how to register an OAuth Application (for local) to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,17 @@ A ranked voting system with github authentication.
 
 # Local testing
 
+You need to have node.js installed ([Download](https://nodejs.org/en/)), then restart, after restarting call `npm update`.
+
 Install the dependencies:
 ```bash
 npm install
 ```
 
-Run the server:
+Now you need to get your github client id and secret id so I would suggest create an OAuth just for Ranked-Vote.  Go to github settings (personal settings), then go to `OAuth applications` then click `Register a new application`.  Then make sure your application settings look like this:
+![image](https://cloud.githubusercontent.com/assets/22880786/22193369/f222d1c0-e18e-11e6-8e5e-fe10f6d235eb.png)
+
+Now you can choose to run the server:
 ```bash
 # The github client id and secret can be found on the integration page
 GITHUB_CLIENT_ID=... GITHUB_CLIENT_SECRET=... npm start
@@ -21,6 +26,7 @@ PORT        -  the port node listens on (defaults to 3000)
 NODE_ENV    -  the enviroment node runs on (development, production and test) 
                and defaults to development
 ```
+
 # ESLint
 An ESLint config file have been added for those that want to use it. It is based on 
 [Felix Geisendörfer's](http://felixge.de/)[Node.js Style Guide](https://github.com/felixge/node-style-guide)


### PR DESCRIPTION
Since registering an OAuth Application for a local server (in this case Ranked-Vote) is quite difficult and unintuitive, I just added a quick amendment to the readme.md.  The main issue was just the fact the authentication callback wasn't stated anywhere and required me to look in code and follow it through (since it wasn't stated holistically in code just pieces like `/github` and `/callback` and so on.  Anyways yah first PR on my side :D (for Ranked-Vote that is).

## Note:
I know it's from my master but I forgot to make it create a branch, and since it's just a readme change felt it was semi-acceptable (or rather like 'who cares' to a degree) happy to create a new branch on my fork and pull that in if it's really a concern.